### PR TITLE
PyPI packaging + CI/CD workflows (#6)

### DIFF
--- a/.claude/commands/daily-checkin.md
+++ b/.claude/commands/daily-checkin.md
@@ -5,12 +5,12 @@ Perform a daily check-in on the SRG project by reviewing open GitHub issues and 
 ### Step 1: Fetch Issues
 
 **Primary method — GitHub MCP:**
-First, use `ToolSearch` to fetch the `mcp__github__list_issues` tool (it is a deferred tool that must be loaded before use). Then call `mcp__github__list_issues` with `owner: "medullalabs"`, `repo: "srg"`, `state: "OPEN"` to list all open issues.
+First, use `ToolSearch` to fetch the `mcp__github__list_issues` tool (it is a deferred tool that must be loaded before use). Then call `mcp__github__list_issues` with `owner: "medullalabs"`, `repo: "semantic-reasoning-graph"`, `state: "OPEN"` to list all open issues.
 
 **Fallback — gh CLI:**
 If the MCP tools fail or are unavailable, fall back to the `gh` CLI:
 ```
-gh issue list -R medullalabs/srg --state open --limit 50 --json number,title,labels,milestone,assignees,createdAt,updatedAt
+gh issue list -R medullalabs/semantic-reasoning-graph --state open --limit 50 --json number,title,labels,milestone,assignees,createdAt,updatedAt
 ```
 
 ### Step 2: Analyze and Prioritize

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Pytest
+        run: pytest tests/ -v
+
+  quality:
+    name: lint + typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Ruff
+        run: ruff check srg/ tests/
+      - name: Mypy
+        run: mypy srg/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build sdist + wheel
+        run: python -m build
+      - name: Verify wheel bundles schemas and examples
+        run: |
+          python -m zipfile -l dist/*.whl | grep -E "schemas/.*\.json" || (echo "Wheel missing schema files" && exit 1)
+          python -m zipfile -l dist/*.whl | grep -E "examples/.*\.(yaml|py)" || (echo "Wheel missing example files" && exit 1)
+          python -m zipfile -l dist/*.whl | grep -E "py\.typed" || (echo "Wheel missing py.typed marker" && exit 1)
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: contains(github.ref_name, 'rc') || contains(github.ref_name, 'a') || contains(github.ref_name, 'b')
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/semantic-reasoning-graph
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    if: "!contains(github.ref_name, 'rc') && !contains(github.ref_name, 'a') && !contains(github.ref_name, 'b')"
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/semantic-reasoning-graph
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-16
+
+Initial public release.
+
+### Added
+
+- Pydantic v2 data models: `ReasoningNode`, `ReasoningEdge`, `ReasoningGraph`, `EvidenceRecord`, `NodeExecutionResult`, `GraphExecutionResult`.
+- Two node kinds: `DETERMINISTIC` and `AGENTIC` (scope-guarded — no other kinds permitted).
+- Agentic execution kernel (`srg.kernel.agentic_call`): prompt → LLM → JSON parse → schema validation → contract check → retry → evidence emission.
+- String-based contracts: `score in 0..100`, `field is nonempty`, `field exists`, comparisons.
+- Graph runtime: YAML loader, structural validator (duplicate IDs, invalid edges, missing schemas/contracts on agentic nodes, cycle detection via Kahn's algorithm), topological planner, graph runner.
+- `DeterministicRegistry` mapping `function_ref` strings to Python callables.
+- Evidence aggregator + summary for post-run analysis and debugging.
+- `semantic_diff` — structural graph comparison detecting added/removed nodes, rewired edges, changed contracts, kind switches.
+- `compose_graphs` — explicit, validated composition of multiple reasoning graphs.
+- `srg` CLI: `validate`, `run`, `diff` subcommands.
+- Example graphs: `validator_scorer.yaml`, `repo_risk.yaml`, `subnet_scorer.yaml`.
+- JSON schemas for graph and evidence records (bundled in the wheel).
+- Scope-guard test suite preventing drift toward workflow, orchestration, adapter, or infrastructure abstractions.
+
+[Unreleased]: https://github.com/medullalabs/semantic-reasoning-graph/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/medullalabs/semantic-reasoning-graph/releases/tag/v0.1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a
+      fee for, acceptance of support, warranty, indemnity, or other
+      liability obligations and/or rights consistent with this License.
+      However, in accepting such obligations, You may act only on Your
+      own behalf and on Your sole responsibility, not on behalf of any
+      other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by,
+      or claims asserted against, such Contributor by reason of your
+      accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Medulla Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # SRG -- Semantic Reasoning Graph
 
+[![PyPI](https://img.shields.io/pypi/v/semantic-reasoning-graph.svg)](https://pypi.org/project/semantic-reasoning-graph/)
+[![Python versions](https://img.shields.io/pypi/pyversions/semantic-reasoning-graph.svg)](https://pypi.org/project/semantic-reasoning-graph/)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![CI](https://github.com/medullalabs/semantic-reasoning-graph/actions/workflows/ci.yml/badge.svg)](https://github.com/medullalabs/semantic-reasoning-graph/actions/workflows/ci.yml)
+
 SRG is a **structural safety net for reasoning-centric systems**. It describes computation as typed nodes connected by explicit data-flow edges, with contract-enforced agentic execution and automatic evidence trails. Two node kinds: **deterministic** (pure Python functions) and **agentic** (LLM calls with JSON schema validation, contract checking, and automatic retry).
 
 SRG's value is not making edits easier -- a capable LLM can edit Python equally well. The value is making edits **safer**: structural validation catches bugs (duplicate nodes, invalid edges, cycles, missing schemas) that Python silently accepts. Contracts prevent silent reasoning degradation. Evidence provides automatic, structured debugging without custom logging.
@@ -29,6 +34,12 @@ Systems where **the cost of a silent reasoning bug exceeds the cost of framework
 - Systems that will be iteratively modified (contracts catch regressions)
 - Teams where non-coders need to review reasoning structure
 - Systems that need audit trails without custom logging
+
+## Install
+
+```bash
+pip install semantic-reasoning-graph
+```
 
 ## Quick example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,37 @@ requires = ["setuptools>=68.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "srg"
-version = "0.1.0"
+name = "semantic-reasoning-graph"
+dynamic = ["version"]
+description = "A semantic IR for reasoning structure with contract-enforced agentic execution and automatic evidence trails."
+readme = "README.md"
 requires-python = ">=3.11"
+license = {text = "Apache-2.0"}
+authors = [
+    {name = "Medulla Labs", email = "bob@tribit.io"},
+]
+keywords = [
+    "llm",
+    "agents",
+    "reasoning",
+    "semantic-graph",
+    "contracts",
+    "evidence",
+    "ir",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
 dependencies = [
     "pydantic>=2.0",
     "pyyaml>=6.0",
@@ -17,10 +45,26 @@ dev = [
     "mypy>=1.0",
     "ruff>=0.4",
     "types-PyYAML>=6.0",
+    "build>=1.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/medullalabs/semantic-reasoning-graph"
+Repository = "https://github.com/medullalabs/semantic-reasoning-graph"
+Issues = "https://github.com/medullalabs/semantic-reasoning-graph/issues"
+Changelog = "https://github.com/medullalabs/semantic-reasoning-graph/blob/main/CHANGELOG.md"
 
 [project.scripts]
 srg = "srg.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["srg*"]
+exclude = ["tests*", "benchmarks*"]
+
+[tool.setuptools.package-data]
+srg = ["schemas/*.json", "examples/*.yaml", "examples/*.py", "py.typed"]
+
+[tool.setuptools_scm]
 
 [tool.mypy]
 strict = true

--- a/srg/__init__.py
+++ b/srg/__init__.py
@@ -1,6 +1,11 @@
 """SRG — Semantic Reasoning Graph."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("semantic-reasoning-graph")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
 
 from srg.models.graph import ReasoningGraph
 from srg.models.node import ReasoningNode, NodeKind


### PR DESCRIPTION
## Summary

Finishes Issue #6 — makes SRG installable via `pip install semantic-reasoning-graph` — and adds the baseline CI/CD that a Python library published to PyPI should have.

- **Packaging:** complete `pyproject.toml` metadata, dynamic version via `setuptools-scm` (git tag is the single source of truth), bundled schemas/examples/`py.typed` in the wheel, Apache-2.0 `LICENSE`, seeded `CHANGELOG.md`. `srg.__version__` now reads from distribution metadata so it always agrees with the built artifact.
- **CI** (`.github/workflows/ci.yml`): test matrix on Python 3.11/3.12/3.13 + separate ruff + `mypy --strict` quality job on every push/PR.
- **Release** (`.github/workflows/release.yml`): tag-triggered. Build job produces sdist + wheel and verifies schemas/examples/`py.typed` are bundled before upload. Publishes via **Trusted Publishing (OIDC)** — no long-lived PyPI tokens. Pre-release tags (`vX.Y.Zrc*`, `aN`, `bN`) publish to **TestPyPI** via the `testpypi` environment; final tags publish to **PyPI** via the `pypi` environment (recommend requiring a reviewer on `pypi` for a human safety rail).
- README: PyPI/Python/License/CI badges + install snippet.
- Second small commit updates the `daily-checkin` slash command for the repo rename that landed earlier.

## Verified locally

- `python -m build` produces wheel + sdist bundling all expected package-data.
- Fresh-venv install from the wheel: `import srg` works, `srg --help` works, schemas resolve via `importlib.resources`, example graph loads + validates.
- 281/281 tests pass; `ruff check` and `mypy srg/` clean.

## Manual one-time setup (must happen before the first tag push)

- [ ] Register a pending Trusted Publisher on **pypi.org** for this repo + `release.yml`, environment `pypi`
- [ ] Register a pending Trusted Publisher on **test.pypi.org**, environment `testpypi`
- [ ] Create `pypi` and `testpypi` environments in repo Settings → Environments (recommended: require reviewer for `pypi`)

## Release plan (post-merge)

- [ ] `git tag v0.1.0rc1 && git push --tags` → workflow publishes to TestPyPI
- [ ] Smoke test: `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ semantic-reasoning-graph` in a clean venv; verify `import srg` and `srg --help`
- [ ] `git tag v0.1.0 && git push --tags` → workflow publishes to PyPI
- [ ] Close #6 referencing the GitHub Release

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly packaging/CI/CD changes, but they affect build/release automation and distribution metadata; misconfiguration could break installs or publish incorrect artifacts.
> 
> **Overview**
> Prepares the project for PyPI distribution under the new name `semantic-reasoning-graph`: expands `pyproject.toml` metadata, switches to dynamic versioning via `setuptools-scm`, and ensures package data (schemas/examples/`py.typed`) is included in built wheels.
> 
> Adds GitHub Actions workflows for CI (pytest matrix + ruff/mypy) and tag-triggered releases that build artifacts, verify wheel contents, and publish to TestPyPI/PyPI via OIDC Trusted Publishing; also adds `LICENSE`, a seeded `CHANGELOG.md`, README badges/install snippet, updates `srg.__version__` to read from package metadata, and adjusts the `daily-checkin` command for the repo rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc492674011c1b2f29417fe549c113476a5bdcce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->